### PR TITLE
Use `main` branch instead of `master`

### DIFF
--- a/lib/src/fetch_page.dart
+++ b/lib/src/fetch_page.dart
@@ -11,7 +11,7 @@ import 'page.dart';
 import 'parse.dart';
 
 final String baseUrl =
-    'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/';
+    'https://raw.githubusercontent.com/tldr-pages/tldr/main/pages/';
 
 Iterable<String> get prefixes {
   var folders = ['common'];


### PR DESCRIPTION
[About 1.5 years ago](https://github.com/tldr-pages/tldr/discussions/5868), we deprecated the `master` branch in favor of the `main` branch. We intend to remove it [soon, likely by May 1st 2023](https://github.com/tldr-pages/tldr/issues/9628).